### PR TITLE
Fix typo in a config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ## Configuration
 
-Tune example `horta.properties` file. All options are self-explanatory.
+Tune example `horta.properties` file. All options should be self-explanatory.
 
 ## Command system
 

--- a/horta.properties
+++ b/horta.properties
@@ -6,7 +6,7 @@ message=Hell installed!
 
 rooms=room1,room2,room3
 room1.room=foo@baz.bar
-room1.name=Architect of Fate
+room1.nickname=Architect of Fate
 room1.message=Just as planned!
 
 room2.room=example@example.org


### PR DESCRIPTION
Looks like there is a typo in the config, where `room.name` is used instead of `room.nickname`. Beware, though: I'm not familiar with codebase, and the only checks I did were grepping — it might just as well be that "name" is indeed valid. In that case, though, its meaning should be clarified in the config (I've never seen or used the project, so I'm a total newbie — I can tell what is and isn't obvious to uninitiated ones).

I also changed phrasing in README a bit, just because it sounds a bit more polite this way.
