### PR TITLE
UTF-8 in configuration file.

### DIFF
--- a/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
+++ b/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
@@ -1,12 +1,12 @@
 package ru.org.codingteam.horta.configuration
 
 import java.util.Properties
-import java.io.FileInputStream
+import java.io.{FileInputStream, InputStreamReader}
 
 object Configuration {
 	private lazy val properties = {
 		val properties = new Properties()
-		val stream = new FileInputStream("horta.properties")
+		val stream = new InputStreamReader(new FileInputStream("horta.properties"), "UTF8")
 		try {
 			properties.load(stream)
 		} finally {


### PR DESCRIPTION
It seems Horta doesn't support UTF-8 symbols in configuration file. Should it?
