### PR TITLE
Probably a fix of issue #87

### DIFF
--- a/src/main/scala/ru/org/codingteam/horta/protocol/jabber/JabberProtocol.scala
+++ b/src/main/scala/ru/org/codingteam/horta/protocol/jabber/JabberProtocol.scala
@@ -53,7 +53,7 @@ class JabberProtocol() extends Actor with ActorLogging {
 
     case JoinRoom(jid, nickname, greeting) =>
       log.info(s"Joining room $jid")
-      val actor = context.actorOf(Props(new MucMessageHandler(self, jid)), jid)
+      val actor = context.actorOf(Props(new MucMessageHandler(self, jid, nickname)), jid)
 
       val muc = new MultiUserChat(connection, jid)
       rooms = rooms.updated(jid, RoomDefinition(muc, actor))

--- a/src/main/scala/ru/org/codingteam/horta/protocol/jabber/MucMessageHandler.scala
+++ b/src/main/scala/ru/org/codingteam/horta/protocol/jabber/MucMessageHandler.scala
@@ -14,11 +14,11 @@ import scala.Some
 /**
  * Multi user chat message handler.
  */
-class MucMessageHandler(val protocol: ActorRef, val roomJID: String) extends Actor with ActorLogging {
+class MucMessageHandler(val protocol: ActorRef, val roomJID: String, val nickname: String) extends Actor with ActorLogging {
 
   val core = context.actorSelection("/user/core")
 
-  var participants = Map[String, Affinity]()
+  var participants = Map[String, Affinity](s"$roomJID/$nickname" -> User)
 
   override def preStart() {
     super.preStart()


### PR DESCRIPTION
Actually, nothing really bad happens here, but the message itself is very confusing. After ~2 hours of investigation I found it very difficult to get rid of the message correctly. So, I decided to try just sending `UserJoin` from `JabberProtocol` to the message handler on joining the room. Hope it doesn't break anything. At least, on my local machine it works fine.
