### PR TITLE
Store nicknames in varchar

### DIFF
--- a/src/main/resources/db/Karma/V4__Nickname-length.sql
+++ b/src/main/resources/db/Karma/V4__Nickname-length.sql
@@ -1,0 +1,5 @@
+alter table Karma
+alter column member varchar;
+
+alter table KarmaChanges
+alter column member varchar;

--- a/src/main/resources/db/log/V4__Nickname-length.sql
+++ b/src/main/resources/db/log/V4__Nickname-length.sql
@@ -1,0 +1,2 @@
+alter table Log
+alter column sender varchar;

--- a/src/main/resources/db/mail/V3__Nickname-length.sql
+++ b/src/main/resources/db/mail/V3__Nickname-length.sql
@@ -1,0 +1,5 @@
+alter table Mail
+alter column sender varchar;
+
+alter table Mail
+alter column receiver varchar;

--- a/src/main/resources/db/pet/V8__Nickname-length.sql
+++ b/src/main/resources/db/pet/V8__Nickname-length.sql
@@ -1,0 +1,5 @@
+alter table PetCoins
+alter column nick varchar;
+
+alter table PetTransaction
+alter column nickname varchar;

--- a/src/main/resources/db/wtf/V3__Nickname-length.sql
+++ b/src/main/resources/db/wtf/V3__Nickname-length.sql
@@ -1,0 +1,2 @@
+alter table Wtf
+alter column author varchar;


### PR DESCRIPTION
I've changed all database columns that stores nicknames to `varchar`. It should fix all possible issues like #117. Unrestricted `varchar` type in H2 has almost the same performance characteristics as `varchar(255)` if the actual data stored is small enough.
