### PR TITLE
Fix bug in visitor plugin

### DIFF
--- a/src/main/scala/ru/org/codingteam/horta/plugins/visitor/VisitorPlugin.scala
+++ b/src/main/scala/ru/org/codingteam/horta/plugins/visitor/VisitorPlugin.scala
@@ -7,7 +7,7 @@ import org.jivesoftware.smack.util.StringUtils
 import ru.org.codingteam.horta.messages.GetParticipants
 import ru.org.codingteam.horta.plugins.{CommandDefinition, CommandProcessor}
 import ru.org.codingteam.horta.protocol.Protocol
-import ru.org.codingteam.horta.protocol.jabber.Visitor
+import ru.org.codingteam.horta.protocol.jabber.NoneAffiliation
 import ru.org.codingteam.horta.security.{RoomAdminAccess, Credential}
 
 import scala.concurrent.duration._
@@ -41,7 +41,7 @@ class VisitorPlugin extends CommandProcessor {
    */
   override protected def processCommand(credential: Credential, token: Any, arguments: Array[String]): Unit = {
     (credential.location ? GetParticipants).mapTo[Protocol.ParticipantCollection] map { case participants =>
-      val visitors = participants.values.filter(_.role == Visitor).map {
+      val visitors = participants.values.filter(_.affiliation == NoneAffiliation).map {
         participant => StringUtils.parseResource(participant.jid)
       }
 

--- a/src/main/scala/ru/org/codingteam/horta/protocol/jabber/Affiliation.scala
+++ b/src/main/scala/ru/org/codingteam/horta/protocol/jabber/Affiliation.scala
@@ -4,3 +4,4 @@ abstract sealed class Affiliation
 case object Owner extends Affiliation
 case object Admin extends Affiliation
 case object User extends Affiliation
+case object NoneAffiliation extends Affiliation

--- a/src/main/scala/ru/org/codingteam/horta/protocol/jabber/MucParticipantStatusListener.scala
+++ b/src/main/scala/ru/org/codingteam/horta/protocol/jabber/MucParticipantStatusListener.scala
@@ -15,13 +15,13 @@ class MucParticipantStatusListener(muc: MultiUserChat, room: ActorRef) extends D
     val affiliation = affiliationName match {
       case "owner" => Owner
       case "admin" => Admin
-      case _ => User
+      case "none" => NoneAffiliation
+      case _ => User // TODO: Check the real value for user if it exist. Currently I have no time to experiment. ~ F
     }
 
     val role = roleName match {
       case "moderator" => Moderator
       case "participant" => Participant
-      case _ => Visitor // TODO: Check the real value for visitor. Currently I have no time to experiment. ~ F
     }
 
     room ! UserJoined(participant, affiliation, role)

--- a/src/main/scala/ru/org/codingteam/horta/protocol/jabber/Role.scala
+++ b/src/main/scala/ru/org/codingteam/horta/protocol/jabber/Role.scala
@@ -3,5 +3,4 @@ package ru.org.codingteam.horta.protocol.jabber
 abstract sealed class Role
 case object Moderator extends Role
 case object Participant extends Role
-case object Visitor extends Role
 


### PR DESCRIPTION
Thanks to @Svoloch we've found and fixed the bug in `VisitorPlugin`. It seems that visitor role does not exists but so-called "none" affiliation does. We've used and checked the new model.