### PR TITLE
Simplify Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: scala
 jdk: oraclejdk8
-sudo: false
 scala:
   - 2.11.4
 notifications:


### PR DESCRIPTION
`sudo: false` is the default option now, there is no need to mention it explicitly. Somehow it even runs faster without it! (But uses the same container-based aka "fast" infrastructure.)