### PR TITLE
Enable integration tests

### DIFF
--- a/src/main/scala/ru/org/codingteam/horta/Application.scala
+++ b/src/main/scala/ru/org/codingteam/horta/Application.scala
@@ -1,5 +1,7 @@
 package ru.org.codingteam.horta
 
+import java.nio.file.Paths
+
 import akka.actor.{ActorSystem, Props}
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
@@ -24,6 +26,6 @@ object Application extends App with StrictLogging {
       case _ => "horta.properties"
     }
 
-    Configuration.initialize(configPath)
+    Configuration.initialize(Paths.get(configPath))
   }
 }

--- a/src/main/scala/ru/org/codingteam/horta/Application.scala
+++ b/src/main/scala/ru/org/codingteam/horta/Application.scala
@@ -7,16 +7,48 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 import ru.org.codingteam.horta.configuration.Configuration
 import ru.org.codingteam.horta.core.Core
+import ru.org.codingteam.horta.plugins.HelperPlugin.HelperPlugin
+import ru.org.codingteam.horta.plugins.bash.BashPlugin
+import ru.org.codingteam.horta.plugins.dice.DiceRoller
+import ru.org.codingteam.horta.plugins.htmlreader.HtmlReaderPlugin
+import ru.org.codingteam.horta.plugins.karma.KarmaPlugin
+import ru.org.codingteam.horta.plugins.log.LogPlugin
+import ru.org.codingteam.horta.plugins.loglist.LogListPlugin
+import ru.org.codingteam.horta.plugins.mail.MailPlugin
+import ru.org.codingteam.horta.plugins.markov.MarkovPlugin
+import ru.org.codingteam.horta.plugins.pet.PetPlugin
+import ru.org.codingteam.horta.plugins.visitor.VisitorPlugin
+import ru.org.codingteam.horta.plugins.wtf.WtfPlugin
+import ru.org.codingteam.horta.plugins.{VersionPlugin, AccessPlugin, FortunePlugin}
+import ru.org.codingteam.horta.protocol.jabber.JabberProtocol
 import scalikejdbc.GlobalSettings
 
 object Application extends App with StrictLogging {
 
-  override def main(args: Array[String]) {
-    initializeConfiguration(args)
+  val plugins = List(
+    Props[FortunePlugin],
+    Props[AccessPlugin],
+    Props[LogPlugin],
+    Props[VisitorPlugin],
+    Props[WtfPlugin],
+    Props[MailPlugin],
+    Props[PetPlugin],
+    Props[MarkovPlugin],
+    Props[VersionPlugin],
+    Props[BashPlugin],
+    Props[DiceRoller],
+    Props[HtmlReaderPlugin],
+     Props[HelperPlugin],
+    Props[KarmaPlugin],
+    Props[LogListPlugin]
+  )
 
-    val system = ActorSystem("CodingteamSystem", ConfigFactory.parseResources("application.conf"))
-    val core = system.actorOf(Props[Core], name = "core")
-  }
+  val protocols = List(Props[JabberProtocol])
+
+  initializeConfiguration(args)
+
+  val system = ActorSystem("CodingteamSystem", ConfigFactory.parseResources("application.conf"))
+  val core = system.actorOf(Props(new Core(plugins, protocols)), "core")
 
   private def initializeConfiguration(args: Array[String]) {
     GlobalSettings.loggingSQLAndTime = GlobalSettings.loggingSQLAndTime.copy(singleLineMode = true)

--- a/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
+++ b/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
@@ -8,21 +8,22 @@ import ru.org.codingteam.horta.localization.LocaleDefinition
 
 object Configuration {
 
-  def initialize(configPath: Path): Unit = {
-    config = Some(Left(configPath))
+  def initialize(path: Path): Unit = {
+    configPath = Some(path)
   }
 
   def initialize(content: String): Unit = {
-    config = Some(Right(content))
+    configContent = Some(content)
   }
 
-  private def openReader(): Reader = config match {
-    case Some(Left(path)) => new InputStreamReader(new FileInputStream(path.toFile), "UTF8")
-    case Some(Right(content)) => new StringReader(content)
-    case None => sys.error("Configuration not defined")
+  private def openReader(): Reader = {
+    configContent.map(content => new StringReader(content))
+      .getOrElse(configPath.map(path => new InputStreamReader(new FileInputStream(path.toFile), "UTF8"))
+        .getOrElse(sys.error("Configuration not defined")))
   }
 
-  private var config: Option[Either[Path, String]] = None
+  private var configPath: Option[Path] = None
+  private var configContent: Option[String] = None
 
   private lazy val properties = {
     val properties = new Properties()

--- a/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
+++ b/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
@@ -32,7 +32,7 @@ object Configuration {
     } finally {
       reader.close()
     }
-    
+
     properties
   }
 
@@ -44,7 +44,7 @@ object Configuration {
   lazy val dftName = properties.getProperty("nickname")
   lazy val dftMessage = properties.getProperty("message")
 
-  lazy val roomIds = properties.getProperty("rooms").split(",")
+  lazy val roomIds = Option(properties.getProperty("rooms")).map(_.split(",")).getOrElse(Array())
   lazy val roomDescriptors = roomIds map {
     case rid => new RoomDescriptor(
       rid,

--- a/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
+++ b/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
@@ -1,26 +1,38 @@
 package ru.org.codingteam.horta.configuration
 
-import java.io.{FileInputStream, InputStreamReader}
+import java.io.{StringReader, Reader, FileInputStream, InputStreamReader}
+import java.nio.file.Path
 import java.util.Properties
 
 import ru.org.codingteam.horta.localization.LocaleDefinition
 
 object Configuration {
 
-  def initialize(configPath: String) {
-    configFilePath = Some(configPath)
+  def initialize(configPath: Path): Unit = {
+    config = Some(Left(configPath))
   }
 
-  private var configFilePath: Option[String] = None
+  def initialize(content: String): Unit = {
+    config = Some(Right(content))
+  }
+
+  private def openReader(): Reader = config match {
+    case Some(Left(path)) => new InputStreamReader(new FileInputStream(path.toFile), "UTF8")
+    case Some(Right(content)) => new StringReader(content)
+    case None => sys.error("Configuration not defined")
+  }
+
+  private var config: Option[Either[Path, String]] = None
 
   private lazy val properties = {
     val properties = new Properties()
-    val stream = new InputStreamReader(new FileInputStream(configFilePath.get), "UTF8")
+    val reader = openReader()
     try {
-      properties.load(stream)
+      properties.load(reader)
     } finally {
-      stream.close()
+      reader.close()
     }
+    
     properties
   }
 

--- a/src/main/scala/ru/org/codingteam/horta/protocol/ProtocolMessage.scala
+++ b/src/main/scala/ru/org/codingteam/horta/protocol/ProtocolMessage.scala
@@ -5,24 +5,24 @@ import akka.actor.ActorRef
 import akka.util.Timeout
 import scala.concurrent.Future
 
-abstract private sealed class ProtocolMessage()
+abstract sealed class ProtocolMessage()
 
-private case class SendMucMessage(toJID: String, message: String) extends ProtocolMessage()
+case class SendMucMessage(toJID: String, message: String) extends ProtocolMessage()
 
-private case class SendPrivateMessage(roomJID: String, nick: String, message: String) extends ProtocolMessage()
+case class SendPrivateMessage(roomJID: String, nick: String, message: String) extends ProtocolMessage()
 
-private case class SendChatMessage(toJID: String, message: String) extends ProtocolMessage()
+case class SendChatMessage(toJID: String, message: String) extends ProtocolMessage()
 
 /**
  * Request to send response to user.
  * @param credential user credential.
  * @param text response text.
  */
-private case class SendResponse(credential: Credential, text: String) extends ProtocolMessage()
+case class SendResponse(credential: Credential, text: String) extends ProtocolMessage()
 
 /**
  * Request to send response to user through the private message.
  * @param credential user credential.
  * @param text response text.
  */
-private case class SendPrivateResponse(credential: Credential, text: String) extends ProtocolMessage()
+case class SendPrivateResponse(credential: Credential, text: String) extends ProtocolMessage()

--- a/src/test/scala/ru/org/codingteam/horta/test/LocalizationManagerSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/LocalizationManagerSpec.scala
@@ -1,5 +1,7 @@
-import org.scalatest.{Matchers, FlatSpec}
-import ru.org.codingteam.horta.localization.{ResourceLocalizationManager, LocaleDefinition, FileLocalizationManager}
+package ru.org.codingteam.horta.test
+
+import org.scalatest.{FlatSpec, Matchers}
+import ru.org.codingteam.horta.localization.{FileLocalizationManager, LocaleDefinition, ResourceLocalizationManager}
 
 class LocalizationManagerSpec extends FlatSpec with Matchers {
 

--- a/src/test/scala/ru/org/codingteam/horta/test/LogPluginSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/LogPluginSpec.scala
@@ -1,0 +1,39 @@
+package ru.org.codingteam.horta.test
+
+import akka.actor.Props
+import ru.org.codingteam.horta.core.Clock
+import ru.org.codingteam.horta.database.{PersistentStore, RepositoryFactory}
+import ru.org.codingteam.horta.localization.LocaleDefinition
+import ru.org.codingteam.horta.plugins.log.{LogRepository, LogPlugin, SearchLogCommand}
+import ru.org.codingteam.horta.plugins.{ProcessCommand, ProcessMessage}
+import ru.org.codingteam.horta.protocol.SendMucMessage
+import ru.org.codingteam.horta.security.{CommonAccess, Credential}
+
+class LogPluginSpec extends TestKitSpec {
+
+  val store = system.actorOf(
+    Props(classOf[PersistentStore], Map(("log", RepositoryFactory("log", LogRepository.apply)))),
+    "store" // TODO: Emulate proper path
+  )
+  val plugin = system.actorOf(Props[LogPlugin]())
+  val credential = Credential(
+    stubReceiver,
+    LocaleDefinition("en"),
+    CommonAccess,
+    Some("testroom"),
+    "testuser",
+    Some("testuser")
+  )
+
+  "LogPlugin" should {
+    "save received message" in {
+      plugin ! ProcessMessage(Clock.now, credential, "test")
+      plugin ! ProcessCommand(credential, SearchLogCommand, Array("test"))
+      val message = expectMsgType[SendMucMessage]
+
+      assert(message.toJID === "testroom")
+      assert(message.message.contains("testuser: "))
+      assert(message.message.contains(" test"))
+    }
+  }
+}

--- a/src/test/scala/ru/org/codingteam/horta/test/MarkovPluginSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/MarkovPluginSpec.scala
@@ -1,9 +1,0 @@
-package ru.org.codingteam.horta.test
-
-import akka.actor.Props
-import ru.org.codingteam.horta.database.{PersistentStore, RepositoryFactory}
-
-class MarkovPluginSpec extends TestKitSpec {
-
-  val store = system.actorOf(Props(classOf[PersistentStore], Map[String, RepositoryFactory]()), "store")
-}

--- a/src/test/scala/ru/org/codingteam/horta/test/MarkovPluginSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/MarkovPluginSpec.scala
@@ -1,0 +1,9 @@
+package ru.org.codingteam.horta.test
+
+import akka.actor.Props
+import ru.org.codingteam.horta.database.{PersistentStore, RepositoryFactory}
+
+class MarkovPluginSpec extends TestKitSpec {
+
+  val store = system.actorOf(Props(classOf[PersistentStore], Map[String, RepositoryFactory]()), "store")
+}

--- a/src/test/scala/ru/org/codingteam/horta/test/PetSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/PetSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 
 class PetSpec extends TestKitSpec {
 
-  val petActor = system.actorOf(Props(classOf[Pet], "roomId", stubReceiver))
+  val petActor = system.actorOf(Props(classOf[Pet], "roomId", testActor))
 
   "Pet" should {
     "Save & return PetData" in within (500.millis) {

--- a/src/test/scala/ru/org/codingteam/horta/test/PetSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/PetSpec.scala
@@ -1,3 +1,5 @@
+package ru.org.codingteam.horta.test
+
 import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
 import akka.event.LoggingReceive
 import akka.testkit.{ImplicitSender, TestKit}
@@ -5,8 +7,9 @@ import com.typesafe.config.ConfigFactory
 import org.joda.time.DateTime
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}
-import ru.org.codingteam.horta.plugins.pet.{PetData, Pet}
 import ru.org.codingteam.horta.plugins.pet.Pet.{GetPetDataInternal, SetPetDataInternal}
+import ru.org.codingteam.horta.plugins.pet.{Pet, PetData}
+
 import scala.concurrent.duration._
 
 class PetSpec extends TestKit(ActorSystem("TestSystem", ConfigFactory.parseString(

--- a/src/test/scala/ru/org/codingteam/horta/test/PetSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/PetSpec.scala
@@ -1,34 +1,13 @@
 package ru.org.codingteam.horta.test
 
-import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
-import akka.event.LoggingReceive
-import akka.testkit.{ImplicitSender, TestKit}
-import com.typesafe.config.ConfigFactory
+import akka.actor.Props
 import org.joda.time.DateTime
-import org.scalatest.concurrent.Eventually
-import org.scalatest.{Matchers, OptionValues, WordSpecLike}
 import ru.org.codingteam.horta.plugins.pet.Pet.{GetPetDataInternal, SetPetDataInternal}
 import ru.org.codingteam.horta.plugins.pet.{Pet, PetData}
 
 import scala.concurrent.duration._
 
-class PetSpec extends TestKit(ActorSystem("TestSystem", ConfigFactory.parseString(
-  """
-    |akka.loglevel = INFO
-    |akka.actor.debug.receive = on
-    |akka.actor.deployment {
-    |}
-  """.stripMargin)))
-with ImplicitSender
-with WordSpecLike
-with Matchers
-with OptionValues
-with Eventually {
-  val stubReceiver = system.actorOf(Props(new Actor with ActorLogging {
-    override def receive = LoggingReceive {
-      case _ =>
-    }
-  }), "stubReceiver")
+class PetSpec extends TestKitSpec {
 
   val petActor = system.actorOf(Props(classOf[Pet], "roomId", stubReceiver))
 

--- a/src/test/scala/ru/org/codingteam/horta/test/TestKitSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/TestKitSpec.scala
@@ -1,12 +1,17 @@
 package ru.org.codingteam.horta.test
 
-import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
-import akka.event.LoggingReceive
+import akka.actor._
 import akka.testkit.{ImplicitSender, TestKit}
+import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}
 import ru.org.codingteam.horta.configuration.Configuration
+import ru.org.codingteam.horta.core.Core
+import ru.org.codingteam.horta.plugins.log.LogPlugin
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 abstract class TestKitSpec extends TestKit(ActorSystem("TestSystem", ConfigFactory.parseString(
   """
@@ -20,10 +25,16 @@ with WordSpecLike
 with Matchers
 with OptionValues
 with Eventually {
-  Configuration.initialize("")
-  val stubReceiver = system.actorOf(Props(new Actor with ActorLogging {
-    override def receive = LoggingReceive {
-      case _ =>
-    }
-  }), "stubReceiver")
+  implicit val timeout = Timeout(15.seconds)
+
+  Configuration.initialize(
+    """
+      |storage.url=jdbc:h2:hell_test;DB_CLOSE_DELAY=-1
+      |storage.user=sa
+      |storage.password=
+      |""".stripMargin)
+
+  val pluginProps = List[Props]()
+  val core = system.actorOf(Props(new Core(List(Props[LogPlugin]), List())) , "core")
+  val plugins = Await.result(Core.getPluginDefinitions(core), timeout.duration)
 }

--- a/src/test/scala/ru/org/codingteam/horta/test/TestKitSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/TestKitSpec.scala
@@ -6,6 +6,7 @@ import akka.testkit.{ImplicitSender, TestKit}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{Matchers, OptionValues, WordSpecLike}
+import ru.org.codingteam.horta.configuration.Configuration
 
 abstract class TestKitSpec extends TestKit(ActorSystem("TestSystem", ConfigFactory.parseString(
   """
@@ -19,6 +20,7 @@ with WordSpecLike
 with Matchers
 with OptionValues
 with Eventually {
+  Configuration.initialize("")
   val stubReceiver = system.actorOf(Props(new Actor with ActorLogging {
     override def receive = LoggingReceive {
       case _ =>

--- a/src/test/scala/ru/org/codingteam/horta/test/TestKitSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/TestKitSpec.scala
@@ -1,0 +1,27 @@
+package ru.org.codingteam.horta.test
+
+import akka.actor.{Actor, ActorLogging, ActorSystem, Props}
+import akka.event.LoggingReceive
+import akka.testkit.{ImplicitSender, TestKit}
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{Matchers, OptionValues, WordSpecLike}
+
+abstract class TestKitSpec extends TestKit(ActorSystem("TestSystem", ConfigFactory.parseString(
+  """
+    |akka.loglevel = INFO
+    |akka.actor.debug.receive = on
+    |akka.actor.deployment {
+    |}
+  """.stripMargin)))
+with ImplicitSender
+with WordSpecLike
+with Matchers
+with OptionValues
+with Eventually {
+  val stubReceiver = system.actorOf(Props(new Actor with ActorLogging {
+    override def receive = LoggingReceive {
+      case _ =>
+    }
+  }), "stubReceiver")
+}


### PR DESCRIPTION
I've refactored code a bit so it can be executed in a test context. Also there is a test example (see `LogPluginSpec`. Now we can easily create integration tests for all new code, it should be sufficient to close #310.