### PR TITLE
jCenter platonus dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.11.4"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
-resolvers += "bintray-fornever-maven" at "http://dl.bintray.com/fornever/maven"
+resolvers += Resolver.jcenterRepo
 
 libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % "2.1.2",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.6


### PR DESCRIPTION
I've managed to publish platonus to [jCenter](https://bintray.com/bintray/jcenter) and think that's better to update the repository link. IMHO jCenter can / should be more trusted than my personal bintray repository.

I had to update sbt version to 0.13.6 because it supports jCenter only beginning from this version.