### PR TITLE
Use total seconds in period comparison

### DIFF
--- a/src/main/scala/ru/org/codingteam/horta/core/Clock.scala
+++ b/src/main/scala/ru/org/codingteam/horta/core/Clock.scala
@@ -1,6 +1,6 @@
 package ru.org.codingteam.horta.core
 
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.{Period, DateTime, DateTimeZone}
 
 /**
  * Object for time manipulating.
@@ -9,4 +9,8 @@ object Clock {
 
   def now = DateTime.now(DateTimeZone.UTC)
 
+  def timeout(seconds: Int, prevTime: DateTime, currTime: DateTime): Boolean = {
+    val period = new Period(prevTime, currTime)
+    period.toStandardSeconds.getSeconds > seconds
+  }
 }

--- a/src/main/scala/ru/org/codingteam/horta/plugins/bash/BashPlugin.scala
+++ b/src/main/scala/ru/org/codingteam/horta/plugins/bash/BashPlugin.scala
@@ -1,11 +1,12 @@
 package ru.org.codingteam.horta.plugins.bash
 
-import org.joda.time.{DateTime, Period}
+import org.joda.time.DateTime
 import ru.org.codingteam.horta.core.Clock
 import ru.org.codingteam.horta.localization.Localization
-import ru.org.codingteam.horta.plugins.{CommandProcessor, CommandDefinition, BasePlugin}
+import ru.org.codingteam.horta.plugins.{BasePlugin, CommandDefinition, CommandProcessor}
 import ru.org.codingteam.horta.protocol.Protocol
-import ru.org.codingteam.horta.security.{Credential, CommonAccess}
+import ru.org.codingteam.horta.security.{CommonAccess, Credential}
+
 import scala.io.Source
 
 private object BashCommand
@@ -32,10 +33,9 @@ class BashPlugin extends BasePlugin with CommandProcessor {
         BashForWebResponseParser(bashImForWebResponse) match {
           case Some(BashQuote(number, rate, text)) =>
             val now = Clock.now
-            val period = new Period(lastRequestDateTime, now)
             var response = ""
 
-            if (period.getSeconds > coolDownPeriod) {
+            if (Clock.timeout(coolDownPeriod, lastRequestDateTime, now)) {
               // TODO: Move to the core facility
               response = s"$number $rate\n$text"
               lastRequestDateTime = now
@@ -52,5 +52,4 @@ class BashPlugin extends BasePlugin with CommandProcessor {
       case _ =>
     }
   }
-
 }

--- a/src/test/scala/ru/org/codingteam/horta/core/ClockSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/core/ClockSpec.scala
@@ -1,0 +1,24 @@
+package ru.org.codingteam.horta.core
+
+import org.joda.time.DateTime
+import org.scalatest.{Matchers, FlatSpec}
+
+class ClockSpec extends FlatSpec with Matchers {
+
+  val base = new DateTime(2010, 1, 1, 0, 0)
+
+  "Clock.timeout" should "be false when not timed out" in {
+    val next = new DateTime(2010, 1, 1, 0, 0, 5)
+    assert(!Clock.timeout(10, base, next))
+  }
+
+  it should "be true when timed out" in {
+    val next = new DateTime(2010, 1, 1, 0, 0, 5)
+    assert(Clock.timeout(1, base, next))
+  }
+
+  it should "work correctly with minutes" in {
+    val next = new DateTime(2010, 1, 1, 0, 1, 5) // 01:05 overflow, would be problematic before fix of #344
+    assert(Clock.timeout(10, base, next))
+  }
+}


### PR DESCRIPTION
There was a bug in Bash plugin that generated all the "Не так часто, пожалуйста" crap: #344. This commit will fix the bug.