### PR TITLE
Ignore `s/from/to/` if `from` isn't in the message

### DIFF
--- a/src/main/scala/ru/org/codingteam/horta/plugins/markov/MarkovUser.scala
+++ b/src/main/scala/ru/org/codingteam/horta/plugins/markov/MarkovUser.scala
@@ -100,8 +100,10 @@ class MarkovUser(val room: String, val nick: String) extends Actor with ActorLog
       lastMessage match {
         case Some(message) =>
           val newMessage = message.replace(from, to)
-          lastMessage = Some(newMessage)
-          Protocol.sendResponse(location, credential, newMessage)
+          if (newMessage != message) {
+              lastMessage = Some(newMessage)
+              Protocol.sendResponse(location, credential, newMessage)
+          }
         case None =>
           Protocol.sendResponse(location, credential, localize("No messages for you, sorry.")(credential))
       }


### PR DESCRIPTION
Fixes #378.