### PR TITLE
PrivateMucMessageHandler: get rid of nulls

### DIFF
--- a/src/main/scala/ru/org/codingteam/horta/protocol/jabber/PrivateMucMessageHandler.scala
+++ b/src/main/scala/ru/org/codingteam/horta/protocol/jabber/PrivateMucMessageHandler.scala
@@ -24,8 +24,10 @@ class PrivateMucMessageHandler(muc: ActorRef, nick: String, implicit val executo
     case UserMessage(message) =>
       val jid = message.getFrom
       val text = message.getBody
-      (muc ? GetCredential(jid)) onSuccess {
-        case roomCred: Credential => core ! CoreMessage(Clock.now, roomCred.copy(location = self), text)
+      if (text != null) {
+        (muc ? GetCredential(jid)) onSuccess {
+          case roomCred: Credential => core ! CoreMessage(Clock.now, roomCred.copy(location = self), text)
+        }
       }
   }
 }


### PR DESCRIPTION
I've been researching #98 a bit and found that we have these `null` checks everywhere we trying to get `message.getBody`. Smack seems to be sometimes using these "messages" to signal about various non-message events, so we need to filter that shit.

I wasn't able to reproduce the bug (because it's triggered by some specific XMPP messages we're still not aware about), but I am pretty confident that's the core reason. Just filter these nasty `null`s on the outer side of our API.

Closes #98.