### PR TITLE
Limit Markov message length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,4 +4,8 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.md]
+indent_size = 4

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "0.15.2"
 
 mainClass in (Compile, run) := Some("ru.org.codingteam.horta.Application")
 
-scalaVersion := "2.11.4"
+scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % "2.1.2",
   "org.scalatest" %% "scalatest" % "2.1.5" % "test",
   "com.googlecode.flyway" % "flyway-core" % "2.3",
-  "me.fornever" %% "platonus" % "0.2.1",
+  "me.fornever" %% "platonus" % "0.3",
   "com.typesafe.akka" %% "akka-actor" % "2.3.6",
   "com.typesafe.akka" %% "akka-slf4j" % "2.3.6",
   "com.typesafe.akka" %% "akka-testkit" % "2.3.6" % "test",

--- a/horta.properties.example
+++ b/horta.properties.example
@@ -19,6 +19,7 @@ room3.room=fgs@fds.omg
 localization.default=ru
 
 markov_messages_per_minute=5
+markov_message_word_limit=30
 
 storage.url=jdbc:h2:hell;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE
 storage.user=sa

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.6
+sbt.version=0.13.11

--- a/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
+++ b/src/main/scala/ru/org/codingteam/horta/configuration/Configuration.scala
@@ -56,6 +56,7 @@ object Configuration {
   }
 
   lazy val markovMessagesPerMinute = properties.getProperty("markov_messages_per_minute", "5").toInt
+  lazy val markovMessageWordLimit = properties.getProperty("markov_message_word_limit", "30").toInt
 
   lazy val defaultLocalization = LocaleDefinition(properties.getProperty("localization.default", "en"))
 

--- a/src/main/scala/ru/org/codingteam/horta/plugins/markov/MarkovUser.scala
+++ b/src/main/scala/ru/org/codingteam/horta/plugins/markov/MarkovUser.scala
@@ -172,7 +172,7 @@ class MarkovUser(val room: String, val nick: String) extends Actor with ActorLog
 
   def generatePhrase(network: Network, length: Integer)(implicit credential: Credential): String = {
     for (i <- 1 to 25) {
-      val phrase = network.generate()
+      val phrase = network.generate(Configuration.markovMessageWordLimit)
       if (phrase.length >= length) {
         return phrase.mkString(" ")
       }


### PR DESCRIPTION
I've changed Platonus API and added its usage to the Horta code.

There's no need in additional tests because it's Platonus responsibility to test this API (and it does that indeed).

Also I've updated our scalac and sbt settings, and also expanded a bit our EditorConfig. I don't see a point of creating distinct PR with just these changes, so in a lazy manner I've included them here.