### PR TITLE
Fix problems with SBT Assembly plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: scala
 sudo: false
 jdk: oraclejdk8
-scala:
-  - 2.11.4
-notifications:
-  email:
-    - friedrich@fornever.me
+scala: 2.11.8
+script: sbt assembly

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ libraryDependencies ++= Seq(
   "org.jsoup" % "jsoup" % "1.7.3",
   "io.spray" %% "spray-json" % "1.3.1",
   "com.twitter" % "hbc-core" % "2.2.0"
+    exclude("commons-logging", "commons-logging") // because jcl-over-slf4j is its drop-in replacement
 )
 
 resourceGenerators in Compile <+= genVersionProperties


### PR DESCRIPTION
This PR does two things.

1. It calls `sbt assembly` as a part of our build on Travis so we could notice problems such this earlier.
2. Removes the transitive `commons-logging` dependency that caused our build to fail.