### PR TITLE
HelperPluginSpec: remove the duplicated "should"

### DIFF
--- a/src/test/scala/ru/org/codingteam/horta/test/HelperPluginSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/test/HelperPluginSpec.scala
@@ -22,26 +22,26 @@ class HelperPluginSpec extends TestKitSpec {
 
   "HelperPlugin" should {
     val plugin = system.actorOf(Props[HelperPlugin])
-    "should answer with some text when no arguments are given" in {
+    "answer with some text when no arguments are given" in {
       plugin ! ProcessCommand(credential, ManCommand, Array())
       val message = expectMsgType[SendResponse](timeout.duration)
       assert(!message.text.isEmpty)
       assert(!message.text.equals(errorMessage))
     }
-    "should answer with command usage text when given a command name as an argument" in {
+    "answer with command usage text when given a command name as an argument" in {
       plugin ! ProcessCommand(credential, ManCommand, Array("say"))
       val message = expectMsgType[SendResponse](timeout.duration)
       assert(!message.text.isEmpty)
       assert(!message.text.equals(errorMessage))
     }
-    "should answer with an error message when given more than one arguments" in {
+    "answer with an error message when given more than one arguments" in {
       plugin ! ProcessCommand(credential, ManCommand, Array("invalid", "arguments"))
       val message = expectMsgType[SendResponse](timeout.duration)
       assert(!message.text.isEmpty)
       assert(message.text.equals(errorMessage))
       assert(message.text.contains(credential.name))
     }
-    "should answer with an error message when given an unknown command name" in {
+    "answer with an error message when given an unknown command name" in {
       plugin ! ProcessCommand(credential, ManCommand, Array("notacommand"))
       val message = expectMsgType[SendResponse](timeout.duration)
       assert(!message.text.isEmpty)


### PR DESCRIPTION
As noted by @ttldtor there were some duplicated words in the test log: https://travis-ci.org/codingteam/horta-hell/builds/130206083#L640

This PR should fix that.