### PR TITLE
Project: fix packages

### DIFF
--- a/src/main/scala/ru/org/codingteam/horta/Application.scala
+++ b/src/main/scala/ru/org/codingteam/horta/Application.scala
@@ -8,7 +8,7 @@ import com.typesafe.scalalogging.StrictLogging
 import ru.org.codingteam.horta.configuration.Configuration
 import ru.org.codingteam.horta.core.Core
 import ru.org.codingteam.horta.events.{EventCollector, TwitterEndpoint}
-import ru.org.codingteam.horta.plugins.HelperPlugin.HelperPlugin
+import ru.org.codingteam.horta.plugins.helper.HelperPlugin
 import ru.org.codingteam.horta.plugins.bash.BashPlugin
 import ru.org.codingteam.horta.plugins.diag.DiagnosticPlugin
 import ru.org.codingteam.horta.plugins.dice.DiceRoller

--- a/src/main/scala/ru/org/codingteam/horta/plugins/helper/HelperPlugin.scala
+++ b/src/main/scala/ru/org/codingteam/horta/plugins/helper/HelperPlugin.scala
@@ -1,4 +1,4 @@
-package ru.org.codingteam.horta.plugins.HelperPlugin
+package ru.org.codingteam.horta.plugins.helper
 
 import akka.pattern.ask
 import akka.util.Timeout

--- a/src/test/scala/ru/org/codingteam/horta/events/EventCollectorSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/events/EventCollectorSpec.scala
@@ -1,9 +1,9 @@
-package ru.org.codingteam.horta.test
+package ru.org.codingteam.horta.events
 
 import akka.actor.Props
 import akka.pattern.ask
-import ru.org.codingteam.horta.events.{EventCollector, EventEndpoint}
 import ru.org.codingteam.horta.messages.{EventMessage, Subscribe, TwitterEvent}
+import ru.org.codingteam.horta.test.TestKitSpec
 
 class EventCollectorSpec extends TestKitSpec {
 

--- a/src/test/scala/ru/org/codingteam/horta/localization/LocalizationManagerSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/localization/LocalizationManagerSpec.scala
@@ -1,7 +1,6 @@
-package ru.org.codingteam.horta.test
+package ru.org.codingteam.horta.localization
 
 import org.scalatest.{FlatSpec, Matchers}
-import ru.org.codingteam.horta.localization.{FileLocalizationManager, LocaleDefinition, ResourceLocalizationManager}
 
 class LocalizationManagerSpec extends FlatSpec with Matchers {
 

--- a/src/test/scala/ru/org/codingteam/horta/messages/EventSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/messages/EventSpec.scala
@@ -1,7 +1,7 @@
-package ru.org.codingteam.horta.test
+package ru.org.codingteam.horta.messages
 
 import akka.pattern.ask
-import ru.org.codingteam.horta.messages._
+import ru.org.codingteam.horta.test.TestKitSpec
 
 import scala.concurrent.Await
 

--- a/src/test/scala/ru/org/codingteam/horta/plugins/helper/HelperPluginSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/plugins/helper/HelperPluginSpec.scala
@@ -1,11 +1,12 @@
-package ru.org.codingteam.horta.test
+package ru.org.codingteam.horta.plugins.helper
 
 import akka.actor.Props
 import ru.org.codingteam.horta.localization.{LocaleDefinition, Localization}
-import ru.org.codingteam.horta.plugins.HelperPlugin.{HelperPlugin, ManCommand}
+import ru.org.codingteam.horta.plugins.helper.{HelperPlugin, ManCommand}
 import ru.org.codingteam.horta.plugins.ProcessCommand
 import ru.org.codingteam.horta.protocol.SendResponse
 import ru.org.codingteam.horta.security.{CommonAccess, Credential}
+import ru.org.codingteam.horta.test.TestKitSpec
 
 class HelperPluginSpec extends TestKitSpec {
 

--- a/src/test/scala/ru/org/codingteam/horta/plugins/log/LogPluginSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/plugins/log/LogPluginSpec.scala
@@ -1,12 +1,12 @@
-package ru.org.codingteam.horta.test
+package ru.org.codingteam.horta.plugins.log
 
 import akka.actor.Props
 import ru.org.codingteam.horta.core.Clock
 import ru.org.codingteam.horta.localization.LocaleDefinition
-import ru.org.codingteam.horta.plugins.log.{LogPlugin, SearchLogCommand}
 import ru.org.codingteam.horta.plugins.{ProcessCommand, ProcessMessage}
 import ru.org.codingteam.horta.protocol.SendResponse
 import ru.org.codingteam.horta.security.{CommonAccess, Credential}
+import ru.org.codingteam.horta.test.TestKitSpec
 
 class LogPluginSpec extends TestKitSpec {
 

--- a/src/test/scala/ru/org/codingteam/horta/plugins/pet/PetSpec.scala
+++ b/src/test/scala/ru/org/codingteam/horta/plugins/pet/PetSpec.scala
@@ -1,9 +1,9 @@
-package ru.org.codingteam.horta.test
+package ru.org.codingteam.horta.plugins.pet
 
 import akka.actor.Props
 import org.joda.time.DateTime
 import ru.org.codingteam.horta.plugins.pet.Pet.{GetPetDataInternal, SetPetDataInternal}
-import ru.org.codingteam.horta.plugins.pet.{Pet, PetData}
+import ru.org.codingteam.horta.test.TestKitSpec
 
 import scala.concurrent.duration._
 


### PR DESCRIPTION
I like the test package tree to mirror the main package tree, so test classes should be placed into the same packages as the classes they're testing. It helps them to have access to package-internal stuff if they really need to, and also helps to find them in the package tree.

Also `plugins.HelperPlugin` package seems to be named inconsistently; I've fixed that.