### PR TITLE
Remove socket timeouts

### DIFF
--- a/src/main/scala/ru/org/codingteam/horta/protocol/jabber/JabberProtocol.scala
+++ b/src/main/scala/ru/org/codingteam/horta/protocol/jabber/JabberProtocol.scala
@@ -154,22 +154,6 @@ class JabberProtocol() extends Actor with ActorLogging {
 
     val configuration = new ConnectionConfiguration(server)
     configuration.setReconnectionAllowed(false)
-    configuration.setSocketFactory(new SocketFactory {
-      override def createSocket(host: String, port: Int): Socket = {
-        val socket = new Socket(host, port)
-        socket.setSoTimeout(Configuration.xmppTimeout.toMillis.toInt)
-        socket
-      }
-
-      // These aren't used by Smack, no point to implement them
-      override def createSocket(host: String, port: Int, localAddress: InetAddress, localPort: Int): Socket = error()
-
-      override def createSocket(host: InetAddress, port: Int): Socket = error()
-
-      override def createSocket(host: InetAddress, port: Int, inetAddress1: InetAddress, i1: Int): Socket = error()
-
-      private def error() = sys.error("Not supported")
-    })
 
     val connection = new XMPPConnection(configuration)
     val chatManager = connection.getChatManager


### PR DESCRIPTION
This is another try to fix #414.

Current hypothesis is that the socket timeouts added in #415 have been created additional problems: the default socket timeout is "infinite", and I've just added the read timeouts to the place where they weren't supposed to be.

I've tested the slightly changed horta version (commit chain ac08ff1f39f59cc53678f40a130b6a5b90e0006f → f0aeb1870cbceb14eb4fd149082e4aac603aaeb1), and it was reconnecting every 2 hours; probably that's just some XMPP stuff, and definitely not the problem. I'll file another issue about that (maybe we just need to tune XMPP ping timeouts a bit).

I don't think that commit ac08ff1f39f59cc53678f40a130b6a5b90e0006f was essential as a solution to the issue, and that's the reason I've removed that commit from the PR (it will arrive later as part of #408).